### PR TITLE
5 first level elements not being rendered nested layout

### DIFF
--- a/__tests__/unit/complete_layout/nested_layout.test.ts
+++ b/__tests__/unit/complete_layout/nested_layout.test.ts
@@ -55,26 +55,73 @@ describe("Nested Layout Rendering", () => {
 
     const view: View = engine.generateViewFromPaths(paths, "Case A");
     const nodes = view.viewNodes;
-    const a = nodes.find((node: ViewNode) => node.name === "A");
-    const b = nodes.find((node: ViewNode) => node.name === "B");
-    const a1 = nodes.find((node: ViewNode) => node.name === "A1");
-    const b1 = nodes.find((node: ViewNode) => node.name === "B1");
-    const a2 = nodes.find((node: ViewNode) => node.name === "A2");
-    const b2 = nodes.find((node: ViewNode) => node.name === "B2");
+    const A = nodes.find((node: ViewNode) => node.name === "A");
+    const B = nodes.find((node: ViewNode) => node.name === "B");
+    const A1 = nodes.find((node: ViewNode) => node.name === "A1");
+    const B1 = nodes.find((node: ViewNode) => node.name === "B1");
+    const A2 = nodes.find((node: ViewNode) => node.name === "A2");
+    const B2 = nodes.find((node: ViewNode) => node.name === "B2");
 
     expect(nodes.length).toBe(6);
-    expect(a).toBeDefined();
-    expect(a?.parentId).toBeNull();
-    expect(b).toBeDefined();
-    expect(b?.parentId).toBeNull();
-    expect(a1).toBeDefined();
-    //expect(a1?.parentId).toBe(a.viewNodeId);
-    expect(a2).toBeDefined();
-    //expect(a2?.parentId).toBe(a.viewNodeId);
-    expect(b1).toBeDefined();
-    //expect(b1?.parentId).toBe(b.viewNodeId);
-    expect(b2).toBeDefined();
-    //expect(b2?.parentId).toBe(b.viewNodeId);
+    expect(A).toBeDefined();
+    expect(A?.parentId).toBeNull();
+    expect(B).toBeDefined();
+    expect(B?.parentId).toBeNull();
+    expect(A1).toBeDefined();
+    // expect(A1?.parentId).toBe(A.viewNodeId);
+    expect(A2).toBeDefined();
+    //expect(A2?.parentId).toBe(A.viewNodeId);
+    expect(B1).toBeDefined();
+    //expect(B1?.parentId).toBe(B.viewNodeId);
+    expect(B2).toBeDefined();
+    //expect(B2?.parentId).toBe(B.viewNodeId);
+
+    done();
+  });
+
+  it("Childless Paths", (done) => {
+    const paths = [
+      [
+        { identifier: "A", name: "A", type: "TA" },
+      ],
+      [
+        { identifier: "B", name: "B", type: "TB" },
+      ],
+      [
+        { identifier: "C", name: "C", type: "TC" },
+      ]
+    ];
+
+    const engine = new SmartViewEngine(layoutSettings);
+
+    const view: View = engine.generateViewFromPaths(paths, "Childless Case");
+    const nodes = view.viewNodes;
+    const A = nodes.find((node: ViewNode) => node.name === "A");
+    const B = nodes.find((node: ViewNode) => node.name === "B");
+    const C = nodes.find((node: ViewNode) => node.name === "C");
+
+    expect(nodes.length).toBe(3);
+    expect(A).toBeDefined();
+    expect(A?.parentId).toBeNull();
+    expect(B).toBeDefined();
+    expect(B?.parentId).toBeNull();
+    expect(C).toBeDefined();
+    expect(C?.parentId).toBeNull();
+
+    expect(A.width).toBe(15);
+    expect(A.height).toBe(5);
+    expect(A.x).toBe(0);
+    expect(A.y).toBe(0);
+
+    expect(B.width).toBe(15);
+    expect(B.height).toBe(5);
+    expect(B.x).toBe(17);
+    expect(B.y).toBe(0);
+
+    expect(C.width).toBe(15);
+    expect(C.height).toBe(5);
+    expect(C.x).toBe(34);
+    expect(C.y).toBe(0);
 
     done();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peritoz/smart-view-engine",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Advanced automatic layout generator for better graph visualization",
   "author": "diorbert.pereira",
   "main": "dist/lib/index.js",

--- a/src/libs/engine/semantic_engine/semantic_engine.ts
+++ b/src/libs/engine/semantic_engine/semantic_engine.ts
@@ -60,11 +60,14 @@ export class SemanticEngine {
     }
   }
 
-  private addChildToNode(indexFirstElement: number, secondElement: PathElement) {
+  private addChildToNode(
+    indexFirstElement: number,
+    secondElement: PathElement
+  ) {
     const indexChild: number | undefined = this.modelElements[
-        indexFirstElement
-        ].children.findIndex(
-        (e: PathElement) => e.identifier === secondElement.identifier
+      indexFirstElement
+    ].children.findIndex(
+      (e: PathElement) => e.identifier === secondElement.identifier
     );
 
     if (indexChild === -1) {
@@ -81,10 +84,11 @@ export class SemanticEngine {
 
     // Separates parent nodes, with its children
     this.paths.forEach((path: Array<PathElement>) => {
+      // Length >= 2: it handles the parent/child chain
       if (path.length >= 2) {
         for (let j = 0; j < path.length - 1; j++) {
-          let firstElement: PathElement = path[j];
-          let secondElement: PathElement = path[j + 1];
+          const firstElement: PathElement = path[j];
+          const secondElement: PathElement = path[j + 1];
 
           indexFirstElement = objectMap.get(firstElement.identifier);
           indexSecondElement = objectMap.get(secondElement.identifier);
@@ -115,6 +119,13 @@ export class SemanticEngine {
           if (indexSecondElement === undefined) {
             this.addNode(false, objectMap, secondElement);
           }
+        }
+      } else if (path.length === 1) { // Length === 1: it handles elements with no children
+        const element: PathElement = path[0];
+        const indexElement = objectMap.get(element.identifier);
+
+        if (indexElement === undefined) {
+          this.addNode(true, objectMap, element);
         }
       }
     });


### PR DESCRIPTION
This PR solves the issue of childless elements (first-level elements) being ignored during nested layout processing.

The problem was related to the Semantic Engine class, which ignored elements with no children.

Finally, this PR also includes code refactoring.